### PR TITLE
Alpine (musl) to Debian (glibc)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,22 @@ workflows:
             - build-arm64
             - build-amd64
 
+  build-publish-82-debian:
+    jobs:
+      - build-amd64:
+          path: "8.2-debian"
+          tag: "8.2-debian"
+          extra_build_args: '--no-cache'
+      - build-arm64:
+          path: "8.2-debian"
+          tag: "8.2-debian"
+          extra_build_args: '--no-cache'
+      - push-multiarch-image:
+          image: "sctr/docker-symfony:8.2-debian"
+          requires:
+            - build-arm64
+            - build-amd64
+
   build-publish-83:
     jobs:
       - build-amd64:

--- a/8.2-debian/Dockerfile
+++ b/8.2-debian/Dockerfile
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH xcaddy build
 # -----------------------------------------------------
 # App Itself
 # -----------------------------------------------------
-FROM php:$PHP_VERSION-fpm-alpine
+FROM php:$PHP_VERSION-fpm
 
 ARG PORT=9001
 ARG PUBLIC_DIR=public
@@ -23,7 +23,7 @@ ARG PUBLIC_DIR=public
 ENV PORT=$PORT
 ENV PUBLIC_DIR=$PUBLIC_DIR
 
-ENV REQUIRED_PACKAGES="git make zip curl supervisor linux-headers gettext acl fcgi pcre python3 libpq libxslt imagemagick libavif libwebp libpng freetype libjpeg-turbo rabbitmq-c"
+ENV REQUIRED_PACKAGES="git zip curl supervisor gettext acl python3 imagemagick"
 ENV EXTENSIONS="redis apcu ast zip mongodb maxminddb amqp pdo_mysql pdo_pgsql bcmath opcache gettext intl exif sysvmsg sysvsem sysvshm pcntl gmp xsl imagick bz2 gd igbinary uuid"
 
 ENV DOCKER=true
@@ -32,7 +32,7 @@ ENV COMPOSER_ALLOW_SUPERUSER=1 COMPOSER_NO_INTERACTION=1 COMPOSER_CACHE_DIR="/tm
 WORKDIR /app
 
 # Copying manifest files to host
-COPY ./8.2/manifest /
+COPY ./8.2-debian/manifest /
 
 # Caddy
 COPY --from=builder /usr/bin/caddy /usr/local/bin/caddy
@@ -45,14 +45,10 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 RUN chmod +x /usr/local/bin/install-php-extensions
 
 # Install required packages
-RUN apk add --update --no-cache $REQUIRED_PACKAGES
+RUN apt update && apt install -y $REQUIRED_PACKAGES
 
 # Install PHP extensions
 RUN install-php-extensions $EXTENSIONS
-
-# Fix Iconv
-RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted gnu-libiconv
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
 # Install sockets
 RUN CFLAGS="$CFLAGS -D_GNU_SOURCE" docker-php-ext-install sockets && docker-php-ext-enable sockets

--- a/8.2-debian/manifest/etc/caddy/Caddyfile
+++ b/8.2-debian/manifest/etc/caddy/Caddyfile
@@ -1,0 +1,34 @@
+:80, :{$PORT} {
+    root * /app/{$PUBLIC_DIR}
+
+    reverse_proxy /php-fpm-status 127.0.0.1:9000 {
+        transport fastcgi {
+            split .php
+        }
+    }
+
+    redir /index.php* /
+
+    php_fastcgi 127.0.0.1:9000 {
+        trusted_proxies private_ranges
+    }
+
+    file_server
+
+    header / {
+        # Enable cross-site filter (XSS) and tell browser to block detected attacks
+        X-XSS-Protection "1; mode=block"
+        # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
+        X-Content-Type-Options "nosniff"
+        # Disallow the site to be rendered within a frame (clickjacking protection)
+        X-Frame-Options "DENY"
+    }
+
+    log {
+        output stdout
+        format console
+    }
+
+    push
+    encode zstd gzip
+}

--- a/8.2-debian/manifest/etc/supervisor/conf.d/caddy.conf
+++ b/8.2-debian/manifest/etc/supervisor/conf.d/caddy.conf
@@ -1,0 +1,7 @@
+[program:caddy]
+command=/usr/local/bin/caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+autostart=true
+autorestart=true
+priority=10
+stdout_events_enabled=true
+stderr_events_enabled=true

--- a/8.2-debian/manifest/etc/supervisor/conf.d/php-fpm.conf
+++ b/8.2-debian/manifest/etc/supervisor/conf.d/php-fpm.conf
@@ -1,0 +1,13 @@
+[program:php-fpm]
+command=/usr/local/sbin/php-fpm -c /usr/local/etc
+process_name=%(program_name)s_%(process_num)02d
+priority=5
+numprocs=1
+autostart=true
+autorestart=false
+startsecs=0
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0

--- a/8.2-debian/manifest/etc/supervisord.conf
+++ b/8.2-debian/manifest/etc/supervisord.conf
@@ -1,0 +1,28 @@
+[unix_http_server]
+file=/var/run/supervisor.sock   ; (the path to the socket file)
+
+[supervisord]
+loglevel=info                ; (log level;default info; others: debug,warn,trace)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+nodaemon=false               ; (start in foreground if true;default false)
+minfds=1024                  ; (min. avail startup file descriptors;default 1024)
+minprocs=200                 ; (min. avail process descriptors;default 200)
+user=root		     ;
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+
+; [eventlistener:stdout]
+; command = supervisor_stdout
+; buffer_size = 100
+; events = PROCESS_LOG
+; result_handler = supervisor_stdout:event_handler
+
+[include]
+files = /etc/supervisor/conf.d/*.conf

--- a/8.2-debian/manifest/usr/local/etc/php-fpm.d/docker.conf
+++ b/8.2-debian/manifest/usr/local/etc/php-fpm.d/docker.conf
@@ -1,0 +1,21 @@
+[global]
+error_log=/proc/self/fd/2
+
+[www]
+; access.log=/proc/self/fd/2
+access.log=/dev/null
+
+clear_env = no
+
+; Ensure worker stdout and stderr are sent to the main error log.
+catch_workers_output = yes
+decorate_workers_output = no
+; log_limit = 4096
+
+pm = dynamic
+pm.start_servers = 2
+pm.min_spare_servers = 2
+pm.max_spare_servers = 5
+chdir = /
+
+pm.status_path = /php-fpm-status

--- a/8.2-debian/manifest/usr/local/etc/php/conf.d/apc.ini
+++ b/8.2-debian/manifest/usr/local/etc/php/conf.d/apc.ini
@@ -1,0 +1,12 @@
+[apcu]
+apc.shm_size=128M
+apc.enable_cli=1
+apc.rfc1867=1
+; PHP file cache 1 hour
+apc.ttl=3600
+; User cache 2 hour
+apc.user_ttl=7200
+; Garbage collection 1 hour
+apc.gc_ttl=3600
+; check files
+apc.stat=1

--- a/8.2-debian/manifest/usr/local/etc/php/conf.d/opcache.ini
+++ b/8.2-debian/manifest/usr/local/etc/php/conf.d/opcache.ini
@@ -1,0 +1,5 @@
+[opcache]
+opcache.memory_consumption=256M
+opcache.max_accelerated_files=20000
+opcache_enable_file_override=1
+opcache.interned_strings_buffer=16

--- a/8.2-debian/manifest/usr/local/etc/php/conf.d/php.ini
+++ b/8.2-debian/manifest/usr/local/etc/php/conf.d/php.ini
@@ -1,0 +1,14 @@
+[PHP]
+error_reporting = E_ALL
+display_errors = Off
+log_errors = On
+error_log = /proc/self/fd/2
+memory_limit = -1
+max_execution_time = 30
+max_input_time = 30
+expose_php = Off
+date.timezone = UTC
+session_use_strict_mode = 1
+session.auto_start = Off
+short_open_tag = Off
+zend_detect_unicode = Off

--- a/8.2-debian/manifest/usr/local/etc/php/conf.d/realpath.ini
+++ b/8.2-debian/manifest/usr/local/etc/php/conf.d/realpath.ini
@@ -1,0 +1,5 @@
+; maximum memory allocated to store the results
+realpath_cache_size=4096K
+
+; save the results for 10 minutes (600 seconds)
+realpath_cache_ttl=600


### PR DESCRIPTION
Part of related issue [#136](https://github.com/sctr/encoder.bang.com/pull/136)

This PR switches our base PHP image from [php-fpm-alpine](https://hub.docker.com/layers/library/php/8.2-fpm-alpine/images/sha256-f445071227e858c52d0aab62372ad4a7b4f939584fd8df3ef04071f953571f1e?context=explore) to [php-fpm](https://hub.docker.com/layers/library/php/8.2-fpm/images/sha256-d35cb6f410e864206babd25b6ff90d9b0a4d19cef5eb18f0a04935b547bb8bcf?context=explore).

The main thing this accomplishes is replacing `musl` (from Alpine) with `glibc` (from Debian), for greater library support as musl's glibc is leading to compatibility issues.

The compatibility issues we are experiencing:
https://github.com/microsoft/onnxruntime/issues/2909#issuecomment-593591317

We are using the `microsoft/onnxruntime` library as a dependency of the SileroVAD python package for voice activity detection on encoder.
