### PR TITLE
Downgrade from Bookworm -> Bullseye in Dockerfile.

### DIFF
--- a/8.2-debian/Dockerfile
+++ b/8.2-debian/Dockerfile
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH xcaddy build
 # -----------------------------------------------------
 # App Itself
 # -----------------------------------------------------
-FROM php:$PHP_VERSION-fpm
+FROM php:$PHP_VERSION-fpm-bullseye
 
 ARG PORT=9001
 ARG PUBLIC_DIR=public


### PR DESCRIPTION
This Dockerfile was using the latest version of Debian (Bookworm). We need to go down 1 version (Bullseye) to match production.

Otherwise we run into issues with `Pipfile.lock` on encoder which specifies a Python version (3.11) not being used in production.

List of Python Versions supported by Debian:
<img width="411" alt="Screenshot 2024-08-23 at 5 43 59 PM" src="https://github.com/user-attachments/assets/9e07279e-4243-4524-9c12-cddac1dee73e">

More info:
https://wiki.debian.org/Python