### PR TITLE
add caddy-jwt module for CF Access validation

### DIFF
--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -12,7 +12,8 @@ ARG TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH xcaddy build \
     --with github.com/mholt/caddy-ratelimit \
-    --with github.com/pberkel/caddy-storage-redis
+    --with github.com/pberkel/caddy-storage-redis \
+    --with github.com/ggicci/caddy-jwt
 
 # -----------------------------------------------------
 # App Itself

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -12,7 +12,8 @@ ARG TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH xcaddy build \
     --with github.com/mholt/caddy-ratelimit \
-    --with github.com/pberkel/caddy-storage-redis
+    --with github.com/pberkel/caddy-storage-redis \
+    --with github.com/ggicci/caddy-jwt
 
 # -----------------------------------------------------
 # App Itself


### PR DESCRIPTION
Added caddy-jwt module, which can be used for www-development, www-development-rw, etc, to validate that incoming traffic is indeed coming via Cloudflare Access for our specific organisation. Eliminates/simplifies the need for ip restrictions, and is also better validation overall, as others can initiate traffic coming via CF's ips too

Example config:
```
www-developement-rw.example.com {
  jwtauth {
    jwk_url https:/sctr.cloudflareaccess.com/cdn-cgi/access/certs
    from_header Cf-Access-Jwt-Assertion
    issuer_whitelist  https://sctr.cloudflareaccess.com
  }

  reverse_proxy 127.0.0.1:8080
}
```