### PR TITLE
Added and updated caddy-jwt

### DIFF
--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -13,7 +13,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH xcaddy build \
     --with github.com/mholt/caddy-ratelimit \
     --with github.com/pberkel/caddy-storage-redis \
-    --with github.com/ggicci/caddy-jwt
+    --with github.com/ggicci/caddy-jwt@28e0de3db362a787564352ec22e97aa743a371f3 #1.2.0
 
 # -----------------------------------------------------
 # App Itself

--- a/8.5-www/Dockerfile
+++ b/8.5-www/Dockerfile
@@ -24,7 +24,8 @@ RUN CGO_ENABLED=1 \
     --with github.com/dunglas/frankenphp@v${FRANKENPHP_VERSION}=./ \
     --with github.com/dunglas/frankenphp/caddy@v${FRANKENPHP_VERSION}=./caddy/ \
     --with github.com/dunglas/caddy-cbrotli@v1.0.1 \
-    --with github.com/ggicci/caddy-jwt@v1.1.2 \
+    #caddy-jwt 1.2.0
+    --with github.com/ggicci/caddy-jwt@28e0de3db362a787564352ec22e97aa743a371f3 \
     --with github.com/mholt/caddy-ratelimit@v0.1.0 \
     --with github.com/pberkel/caddy-storage-redis@v1.7.0
 

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -11,7 +11,8 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH xcaddy build \
-    --with github.com/ueffel/caddy-brotli
+    --with github.com/ueffel/caddy-brotli \
+    --with github.com/ggicci/caddy-jwt@28e0de3db362a787564352ec22e97aa743a371f3 #1.2.0
 
 # -----------------------------------------------------
 # Build kreuzberg PHP extension from Rust source


### PR DESCRIPTION
- Updated and pinned caddy-jwt to 1.2.0 by commit sha (is more secure to do it by commit as then the 1.2.0 version is immutable and can't be changed later on)
- Added Caddy-jwt to the 8.5 image, for use in API and CMS