### PR TITLE
#9 - Build xberg PHP extension alongside kreuzberg in 8.5 image

### DIFF
--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -40,7 +40,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 ARG KREUZBERG_VERSION=v4.9.8
-RUN git clone --depth 1 --branch ${KREUZBERG_VERSION} https://github.com/kreuzberg-dev/kreuzberg.git /tmp/kreuzberg \
+# v4 LTS moved to kreuzberg-lts; the old repo redirects to xberg-io/xberg which has no v4 tags
+RUN git clone --depth 1 --branch ${KREUZBERG_VERSION} https://github.com/kreuzberg-dev/kreuzberg-lts.git /tmp/kreuzberg \
     && cd /tmp/kreuzberg/crates/kreuzberg-php \
     && for i in 1 2 3 4 5; do \
          cargo build --release && break || { \
@@ -49,6 +50,62 @@ RUN git clone --depth 1 --branch ${KREUZBERG_VERSION} https://github.com/kreuzbe
          }; \
        done \
     && test -f /tmp/kreuzberg/target/release/libkreuzberg_php.so
+
+# -----------------------------------------------------
+# Build xberg PHP extension from Rust source
+# (successor to kreuzberg, see kreuzberg migration docs)
+# -----------------------------------------------------
+FROM php:$PHP_VERSION-fpm AS xberg-builder
+
+# Install build dependencies (tesseract is vendored/statically built by xberg)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        cmake \
+        g++ \
+        pkg-config \
+        libssl-dev \
+        libmagic-dev \
+        libuv1-dev \
+        libde265-dev \
+        libaom-dev \
+        libx265-dev \
+        libdav1d-dev \
+        libnuma-dev \
+        clang \
+        curl \
+        file \
+        git \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# xberg's heic feature links system libheif >= 1.21; trixie ships 1.19
+ARG LIBHEIF_VERSION=1.23.0
+RUN curl -fsSL "https://github.com/strukturag/libheif/releases/download/v${LIBHEIF_VERSION}/libheif-${LIBHEIF_VERSION}.tar.gz" | tar xz -C /tmp \
+    && cmake -S /tmp/libheif-${LIBHEIF_VERSION} -B /tmp/libheif-build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DWITH_EXAMPLES=OFF \
+        -DWITH_GDK_PIXBUF=OFF \
+        -DBUILD_TESTING=OFF \
+    && cmake --build /tmp/libheif-build -j"$(nproc)" \
+    && cmake --install /tmp/libheif-build \
+    && rm -rf /tmp/libheif-*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+ARG XBERG_VERSION=v1.0.0-rc.28
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules --branch ${XBERG_VERSION} https://github.com/xberg-io/xberg.git /tmp/xberg \
+    && cd /tmp/xberg/crates/xberg-php \
+    && for i in 1 2 3 4 5; do \
+         cargo build --release && break || { \
+           echo "cargo build failed (attempt $i), retrying in $((i*30))s..."; \
+           sleep $((i*30)); \
+         }; \
+       done \
+    && test -f /tmp/xberg/target/release/libxberg_php.so
 
 # -----------------------------------------------------
 # App Itself
@@ -96,6 +153,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS} \
         jpegoptim \
         optipng \
         pngquant \
+        # libheif codec runtimes for ext-xberg
+        libde265-0 \
+        libaom3 \
+        libx265-215 \
+        libdav1d7 \
+        libnuma1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 
@@ -103,6 +166,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS} \
 COPY --from=kreuzberg-builder /tmp/kreuzberg/target/release/libkreuzberg_php.so /tmp/kreuzberg.so
 RUN mv /tmp/kreuzberg.so $(php -r "echo ini_get('extension_dir');")/kreuzberg.so \
     && echo "#extension=kreuzberg" > $PHP_INI_DIR/conf.d/kreuzberg.ini
+
+# Xberg PHP extension (built from Rust source), successor to kreuzberg
+COPY --from=xberg-builder /tmp/xberg/target/release/libxberg_php.so /tmp/xberg.so
+RUN mv /tmp/xberg.so $(php -r "echo ini_get('extension_dir');")/xberg.so \
+    && echo "#extension=xberg" > $PHP_INI_DIR/conf.d/xberg.ini
+
+# libheif >= 1.21 runtime for ext-xberg (apt ships older); resolved via LD_LIBRARY_PATH=/usr/local/lib
+COPY --from=xberg-builder /usr/local/lib/libheif.so.1* /usr/local/lib/
 
 # Install latest libvips
 # @see https://github.com/dooman87/imagemagick-docker/blob/main/Dockerfile.bookworm

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -15,45 +15,8 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH xcaddy build \
     --with github.com/ggicci/caddy-jwt@28e0de3db362a787564352ec22e97aa743a371f3 #1.2.0
 
 # -----------------------------------------------------
-# Build kreuzberg PHP extension from Rust source
-# -----------------------------------------------------
-FROM php:$PHP_VERSION-fpm AS kreuzberg-builder
-
-# Install build dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        cmake \
-        g++ \
-        pkg-config \
-        libssl-dev \
-        libleptonica-dev \
-        libtesseract-dev \
-        clang \
-        curl \
-        file \
-        git \
-        && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-ARG KREUZBERG_VERSION=v4.9.8
-# v4 LTS moved to kreuzberg-lts; the old repo redirects to xberg-io/xberg which has no v4 tags
-RUN git clone --depth 1 --branch ${KREUZBERG_VERSION} https://github.com/kreuzberg-dev/kreuzberg-lts.git /tmp/kreuzberg \
-    && cd /tmp/kreuzberg/crates/kreuzberg-php \
-    && for i in 1 2 3 4 5; do \
-         cargo build --release && break || { \
-           echo "cargo build failed (attempt $i), retrying in $((i*30))s..."; \
-           sleep $((i*30)); \
-         }; \
-       done \
-    && test -f /tmp/kreuzberg/target/release/libkreuzberg_php.so
-
-# -----------------------------------------------------
 # Build xberg PHP extension from Rust source
-# (successor to kreuzberg, see kreuzberg migration docs)
+# (successor to kreuzberg)
 # -----------------------------------------------------
 FROM php:$PHP_VERSION-fpm AS xberg-builder
 
@@ -161,11 +124,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS} \
         libnuma1 \
 	&& rm -rf /var/lib/apt/lists/*
 
-
-# Kreuzberg PHP extension (built from Rust source)
-COPY --from=kreuzberg-builder /tmp/kreuzberg/target/release/libkreuzberg_php.so /tmp/kreuzberg.so
-RUN mv /tmp/kreuzberg.so $(php -r "echo ini_get('extension_dir');")/kreuzberg.so \
-    && echo "#extension=kreuzberg" > $PHP_INI_DIR/conf.d/kreuzberg.ini
 
 # Xberg PHP extension (built from Rust source), successor to kreuzberg
 COPY --from=xberg-builder /tmp/xberg/target/release/libxberg_php.so /tmp/xberg.so


### PR DESCRIPTION
Closes #9

## Changes (`8.5/Dockerfile` only)

- **New `xberg-builder` stage**: builds `crates/xberg-php` from [xberg-io/xberg](https://github.com/xberg-io/xberg) at pinned `v1.0.0-rc.28` (no stable tag exists yet — bump `XBERG_VERSION` when one lands), same shape and retry loop as the previous kreuzberg stage. xberg vendors Tesseract statically (no `libtesseract-dev` needed), but its `heic` feature links system **libheif ≥ 1.21**, so the stage builds libheif 1.23.0 from source (trixie apt ships 1.19.8) — mirroring xberg's own CI.
- **Final image**: ships `xberg.so` commented out in `conf.d/xberg.ini`, copies `libheif.so.1` to `/usr/local/lib` (on `LD_LIBRARY_PATH`), and adds the codec runtime packages (`libde265-0 libaom3 libx265-215 libdav1d7 libnuma1`) so the extension is loadable when consumers enable it.
- **Kreuzberg removed** (per review): the `kreuzberg-builder` stage and its extension block are deleted — the image ships only xberg. Note this also drops the broken `v4.9.8` clone (the old `kreuzberg-dev/kreuzberg` repo was renamed to `xberg-io/xberg`, so uncached 8.5 builds were failing on master anyway).

## Verification (local arm64 build)

- Full `docker build` succeeds.
- `extension=xberg` enabled → `php -m` lists `xberg`; `class_exists('Xberg\CacheStats')` → `true`.
- `ldd xberg.so`: zero unresolved libs; `libheif.so.1` resolves to the bundled 1.23 copy.
- No kreuzberg artifacts remain (`conf.d/kreuzberg.ini`, `kreuzberg.so` gone).